### PR TITLE
Disable sailjail

### DIFF
--- a/harbour-syncthing.desktop
+++ b/harbour-syncthing.desktop
@@ -11,3 +11,4 @@ Comment=Continuous Replication Synchronization Thing
 Permissions=Internet;AppLaunch
 OrganizationName=dev.scarpino
 ApplicationName=harbour-syncthing
+Sandboxing=Disabled

--- a/harbour-syncthing.desktop
+++ b/harbour-syncthing.desktop
@@ -8,7 +8,6 @@ Name=Syncthing
 Comment=Continuous Replication Synchronization Thing
 
 [X-Sailjail]
-Permissions=Internet;AppLaunch
+Permissions=Internet;AppLaunch;Privileged
 OrganizationName=dev.scarpino
 ApplicationName=harbour-syncthing
-Sandboxing=Disabled

--- a/rpm/harbour-syncthing.spec
+++ b/rpm/harbour-syncthing.spec
@@ -11,7 +11,7 @@ Name:       harbour-syncthing
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Syncthing
 Version:    0.0.2
-Release:    1
+Release:    2
 Group:      Qt/Qt
 License:    GPLv3
 URL:        https://scarpino.dev


### PR DESCRIPTION
Starting from 4.6.0.13, SailJail prevent the application to syncronize outside of sandbox.
This changes allows Syncthing to access the filesystem once again.

See #1 for discussion